### PR TITLE
适配0.77，当开始原生动画效果时存在递归问题，临时关闭

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -236,7 +236,7 @@ const ScrollableTabView = createReactClass({
         ref={(scrollView) => { this.scrollView = scrollView; }}
         onScroll={Animated.event(
           [{ nativeEvent: { contentOffset: { x: this.state.scrollXIOS, }, }, }, ],
-          { useNativeDriver: true, listener: this._onScroll, }
+          { useNativeDriver: false, listener: this._onScroll, }
         )}
         onMomentumScrollBegin={this._onMomentumScrollBeginAndEnd}
         onMomentumScrollEnd={this._onMomentumScrollBeginAndEnd}
@@ -268,7 +268,7 @@ const ScrollableTabView = createReactClass({
             },
           }, ],
           {
-            useNativeDriver: true,
+            useNativeDriver: false,
             listener: this._onScroll,
           },
         )}


### PR DESCRIPTION
# Summary

- 适配0.77，当开始原生动画效果时存在递归问题，临时关闭。

## Test Plan

<img width="424" height="900" alt="image" src="https://github.com/user-attachments/assets/39a39710-72d5-4fb1-b539-0294381b5aab" />


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
