### PR TITLE
fix:【三方库质量加固】react-native-scrollable-tab-view三方库对比原生库，鸿蒙化版本在 iOS 平台将 useNativeDriver 设置为 false，原生库为true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -222,7 +222,7 @@ const ScrollableTabView = createReactClass({
         ref={(scrollView) => { this.scrollView = scrollView; }}
         onScroll={Animated.event(
           [{ nativeEvent: { contentOffset: { x: this.state.scrollXIOS, }, }, }, ],
-          { useNativeDriver: false, listener: this._onScroll, }
+          { useNativeDriver: true, listener: this._onScroll, }
         )}
         onMomentumScrollBegin={this._onMomentumScrollBeginAndEnd}
         onMomentumScrollEnd={this._onMomentumScrollBeginAndEnd}


### PR DESCRIPTION
- 【RN鸿蒙】【三方库】【react-native-scrollable-tab-view】【三方库质量加固】react-native-scrollable-tab-view三方库对比原生库，鸿蒙化版本在 iOS 平台将 useNativeDriver 设置为 false，原生库为true
修改方案： 改为true

